### PR TITLE
Fix local build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ artifacts {
 
 
 signing {
+    required { gradle.taskGraph.hasTask("uploadArchives") }
     sign configurations.archives
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+ossrhUsername=
+ossrhPassword=


### PR DESCRIPTION
This allows you to build/generate javadocs locally without having to configure for uploading to ossrh. 

- Add local gradle.properties with stubbed out ossrhUsername & password so gradle won't complain when they aren't set globally
- Add check in build.gradle so signing only happens when deploying to sonatype