### PR TITLE
Align tags to a column, and support org-indent-mode's virtual indentation

### DIFF
--- a/src/main/java/com/orgzly/org/parser/OrgParsedFile.java
+++ b/src/main/java/com/orgzly/org/parser/OrgParsedFile.java
@@ -47,4 +47,18 @@ public class OrgParsedFile { // TODO: Extend OrgFile instead?
 
         return str.toString();
     }
+
+    public String toString(OrgParserSettings settings) {
+        StringBuilder str = new StringBuilder();
+
+        OrgParserWriter parserWriter = new OrgParserWriter(settings);
+
+        str.append(parserWriter.whiteSpacedFilePreface(file.getPreface()));
+
+        for (OrgNodeInList nodeInList : headsInList) {
+            str.append(parserWriter.whiteSpacedHead(nodeInList, file.getSettings().isIndented()));
+        }
+
+        return str.toString();
+    }
 }

--- a/src/main/java/com/orgzly/org/parser/OrgParserSettings.java
+++ b/src/main/java/com/orgzly/org/parser/OrgParserSettings.java
@@ -20,9 +20,11 @@ public class OrgParserSettings {
     /* The column to align tags to. A positive int left-aligns to the given
      * column; a negative int right-aligns. */
     public int tagsColumn;
+
     /* Support how `org-indent-mode' shifts tags to the left to offset its
      * virtual indentation. */
-    public int realPlusVirtualIndentationPerLevel;
+    public boolean orgIndentMode;
+    public int orgIndentIndentationPerLevel;
 
     OrgParserSettings() {
         propertyFormat = "%-10s %s";
@@ -33,8 +35,9 @@ public class OrgParserSettings {
         separateNotesWithNewLine = SeparateNotesWithNewLine.MULTI_LINE_NOTES_ONLY;
         separateHeaderAndContentWithNewLine = true;
         tagsColumn = 0;
-        /* Only real indentation by default. */
-        realPlusVirtualIndentationPerLevel = 1;
+
+        orgIndentMode = false;
+        orgIndentIndentationPerLevel = 2;
     }
 
     /**
@@ -50,7 +53,9 @@ public class OrgParserSettings {
 
         this.separateNotesWithNewLine = that.separateNotesWithNewLine;
         this.tagsColumn = that.tagsColumn;
-        this.realPlusVirtualIndentationPerLevel = that.realPlusVirtualIndentationPerLevel;
+
+        this.orgIndentMode = that.orgIndentMode;
+        this.orgIndentIndentationPerLevel = that.orgIndentIndentationPerLevel;
     }
 
     public static OrgParserSettings getBasic() {

--- a/src/main/java/com/orgzly/org/parser/OrgParserSettings.java
+++ b/src/main/java/com/orgzly/org/parser/OrgParserSettings.java
@@ -17,6 +17,9 @@ public class OrgParserSettings {
 
     public SeparateNotesWithNewLine separateNotesWithNewLine;
     public boolean separateHeaderAndContentWithNewLine;
+    /* The column to align tags to. A positive int left-aligns to the given
+     * column; a negative int right-aligns. */
+    public int tagsColumn;
 
     OrgParserSettings() {
         propertyFormat = "%-10s %s";
@@ -26,6 +29,7 @@ public class OrgParserSettings {
 
         separateNotesWithNewLine = SeparateNotesWithNewLine.MULTI_LINE_NOTES_ONLY;
         separateHeaderAndContentWithNewLine = true;
+        tagsColumn = -77;
     }
 
     /**
@@ -40,6 +44,7 @@ public class OrgParserSettings {
         this.doneKeywords.addAll(that.doneKeywords);
 
         this.separateNotesWithNewLine = that.separateNotesWithNewLine;
+        this.tagsColumn = that.tagsColumn;
     }
 
     public static OrgParserSettings getBasic() {

--- a/src/main/java/com/orgzly/org/parser/OrgParserSettings.java
+++ b/src/main/java/com/orgzly/org/parser/OrgParserSettings.java
@@ -20,6 +20,9 @@ public class OrgParserSettings {
     /* The column to align tags to. A positive int left-aligns to the given
      * column; a negative int right-aligns. */
     public int tagsColumn;
+    /* Support how `org-indent-mode' shifts tags to the left to offset its
+     * virtual indentation. */
+    public int realPlusVirtualIndentationPerLevel;
 
     OrgParserSettings() {
         propertyFormat = "%-10s %s";
@@ -30,6 +33,8 @@ public class OrgParserSettings {
         separateNotesWithNewLine = SeparateNotesWithNewLine.MULTI_LINE_NOTES_ONLY;
         separateHeaderAndContentWithNewLine = true;
         tagsColumn = 0;
+        /* Only real indentation by default. */
+        realPlusVirtualIndentationPerLevel = 1;
     }
 
     /**
@@ -45,6 +50,7 @@ public class OrgParserSettings {
 
         this.separateNotesWithNewLine = that.separateNotesWithNewLine;
         this.tagsColumn = that.tagsColumn;
+        this.realPlusVirtualIndentationPerLevel = that.realPlusVirtualIndentationPerLevel;
     }
 
     public static OrgParserSettings getBasic() {

--- a/src/main/java/com/orgzly/org/parser/OrgParserSettings.java
+++ b/src/main/java/com/orgzly/org/parser/OrgParserSettings.java
@@ -29,7 +29,7 @@ public class OrgParserSettings {
 
         separateNotesWithNewLine = SeparateNotesWithNewLine.MULTI_LINE_NOTES_ONLY;
         separateHeaderAndContentWithNewLine = true;
-        tagsColumn = -77;
+        tagsColumn = 0;
     }
 
     /**

--- a/src/main/java/com/orgzly/org/parser/OrgParserWriter.java
+++ b/src/main/java/com/orgzly/org/parser/OrgParserWriter.java
@@ -96,13 +96,13 @@ public class OrgParserWriter {
             int padding = Math.abs(settings.tagsColumn) - s.length();
 
             /* Shift the tags left for users of org-indent-mode.
-
-               The first level of indentation has already been added (the
-               heading asterisks), the indentation we add per level is 1 LESS
-               than settings.realPlusVirtualIndentationPerLevel.
+             *
+             * The first level of indentation has already been added (the
+             * heading asterisks), the indentation we add per level is 1 LESS
+             * than settings.orgIndentIndentationPerLevel.
              */
-            if (settings.realPlusVirtualIndentationPerLevel > 0) {
-                padding -= (settings.realPlusVirtualIndentationPerLevel - 1) * level;
+            if (settings.orgIndentMode && settings.orgIndentIndentationPerLevel > 0) {
+                padding -= (settings.orgIndentIndentationPerLevel - 1) * level;
             }
 
             if (settings.tagsColumn < 0) {

--- a/src/main/java/com/orgzly/org/parser/OrgParserWriter.java
+++ b/src/main/java/com/orgzly/org/parser/OrgParserWriter.java
@@ -102,7 +102,7 @@ public class OrgParserWriter {
              * than settings.orgIndentIndentationPerLevel.
              */
             if (settings.orgIndentMode && settings.orgIndentIndentationPerLevel > 0) {
-                padding -= (settings.orgIndentIndentationPerLevel - 1) * level;
+                padding -= (settings.orgIndentIndentationPerLevel - 1) * (level - 1);
             }
 
             if (settings.tagsColumn < 0) {

--- a/src/main/java/com/orgzly/org/parser/OrgParserWriter.java
+++ b/src/main/java/com/orgzly/org/parser/OrgParserWriter.java
@@ -80,13 +80,29 @@ public class OrgParserWriter {
 
         /* Tags. */
         if (head.hasTags()) {
+            StringBuilder ts = new StringBuilder();
+
+            /* Always add at least one space after the heading. */
             s.append(" ");
 
+            /* String the tags together, separated by colons. */
             for (int i = 0; i < head.getTags().size(); i++) {
-                s.append(":").append(head.getTags().get(i));
+                ts.append(":").append(head.getTags().get(i));
             }
 
-            s.append(":");
+            ts.append(":");
+
+            /* Figure out how many spaces we need to align the tags properly. */
+            int padding = Math.abs(settings.tagsColumn) - s.length();
+            if (settings.tagsColumn < 0) {
+                padding -= ts.length();
+            }
+
+            for (; padding > 0; padding--) {
+                s.append(" ");
+            }
+
+            s.append(ts.toString());
         }
 
         /* Anything that should go right under header, with no new-line in between. */

--- a/src/main/java/com/orgzly/org/parser/OrgParserWriter.java
+++ b/src/main/java/com/orgzly/org/parser/OrgParserWriter.java
@@ -94,6 +94,17 @@ public class OrgParserWriter {
 
             /* Figure out how many spaces we need to align the tags properly. */
             int padding = Math.abs(settings.tagsColumn) - s.length();
+
+            /* Shift the tags left for users of org-indent-mode.
+
+               The first level of indentation has already been added (the
+               heading asterisks), the indentation we add per level is 1 LESS
+               than settings.realPlusVirtualIndentationPerLevel.
+             */
+            if (settings.realPlusVirtualIndentationPerLevel > 0) {
+                padding -= (settings.realPlusVirtualIndentationPerLevel - 1) * level;
+            }
+
             if (settings.tagsColumn < 0) {
                 padding -= ts.length();
             }

--- a/src/test/java/com/orgzly/org/parser/OrgDomyParserTest.java
+++ b/src/test/java/com/orgzly/org/parser/OrgDomyParserTest.java
@@ -118,13 +118,13 @@ public class OrgDomyParserTest {
             "*** TODO Two timestamps (range?)\n" +
             "    SCHEDULED: <2014-10-22 сре>--<2014-10-23 чет>\n" +
             "\n" +
-            "* This is the first line with tag at the end of the line               :tag1:\n" +
-            "** [#A] Second heading with priority                                   :tag2:\n" +
-            "*** TODO [#B] Third heading with spaced priority                       :tag3:\n" +
-            "**** DONE Heading number 4                                         :tag:todo:\n" +
+            "* This is the first line with tag at the end of the line :tag1:\n" +
+            "** [#A] Second heading with priority :tag2:\n" +
+            "*** TODO [#B] Third heading with spaced priority :tag3:\n" +
+            "**** DONE Heading number 4 :tag:todo:\n" +
             "     CLOSED: [2012-12-29 Sat 08:05] DEADLINE: <2012-12-28 Fri> SCHEDULED: <2012-12-27 Thu>\n" +
             "\n" +
-            "***** This is 5                                                         :tag:\n" +
+            "***** This is 5 :tag:\n" +
             "      SCHEDULED: <2013-01-04 Fri 01:00>\n" +
             "      :PROPERTIES:\n" +
             "      :created_at: <2013-06-22 Sat 12:35>\n" +
@@ -135,12 +135,12 @@ public class OrgDomyParserTest {
             "| asd | asd |\n" +
             "| 1   |   2 |\n" +
             "\n" +
-            "****** [#F] OMG, this is 6, not more                                    :tag:\n" +
-            "* Commonly used tags1                                    :tags:help:org:mode:\n" +
-            "* Commonly used tags2                                    :tags:help:org:mode:\n" +
+            "****** [#F] OMG, this is 6, not more :tag:\n" +
+            "* Commonly used tags1 :tags:help:org:mode:\n" +
+            "* Commonly used tags2 :tags:help:org:mode:\n" +
             "* Commonly used tags3:tags:help:org:mode:\n" +
             "* Scheduling\n" +
-            "** TODO Multiple SCHEDULED for a note                              :multiple:\n" +
+            "** TODO Multiple SCHEDULED for a note :multiple:\n" +
             "   SCHEDULED: <2013-01-01>\n" +
             "- State \"DONE\"       from \"TODO\"       [2013-06-22 Sat 14:53]\n" +
             "- State \"DONE\"       from \"TODO\"       [2013-06-22 Sat 14:53]\n" +

--- a/src/test/java/com/orgzly/org/parser/OrgDomyParserTest.java
+++ b/src/test/java/com/orgzly/org/parser/OrgDomyParserTest.java
@@ -118,13 +118,13 @@ public class OrgDomyParserTest {
             "*** TODO Two timestamps (range?)\n" +
             "    SCHEDULED: <2014-10-22 сре>--<2014-10-23 чет>\n" +
             "\n" +
-            "* This is the first line with tag at the end of the line :tag1:\n" +
-            "** [#A] Second heading with priority :tag2:\n" +
-            "*** TODO [#B] Third heading with spaced priority :tag3:\n" +
-            "**** DONE Heading number 4 :tag:todo:\n" +
+            "* This is the first line with tag at the end of the line               :tag1:\n" +
+            "** [#A] Second heading with priority                                   :tag2:\n" +
+            "*** TODO [#B] Third heading with spaced priority                       :tag3:\n" +
+            "**** DONE Heading number 4                                         :tag:todo:\n" +
             "     CLOSED: [2012-12-29 Sat 08:05] DEADLINE: <2012-12-28 Fri> SCHEDULED: <2012-12-27 Thu>\n" +
             "\n" +
-            "***** This is 5 :tag:\n" +
+            "***** This is 5                                                         :tag:\n" +
             "      SCHEDULED: <2013-01-04 Fri 01:00>\n" +
             "      :PROPERTIES:\n" +
             "      :created_at: <2013-06-22 Sat 12:35>\n" +
@@ -135,12 +135,12 @@ public class OrgDomyParserTest {
             "| asd | asd |\n" +
             "| 1   |   2 |\n" +
             "\n" +
-            "****** [#F] OMG, this is 6, not more :tag:\n" +
-            "* Commonly used tags1 :tags:help:org:mode:\n" +
-            "* Commonly used tags2 :tags:help:org:mode:\n" +
+            "****** [#F] OMG, this is 6, not more                                    :tag:\n" +
+            "* Commonly used tags1                                    :tags:help:org:mode:\n" +
+            "* Commonly used tags2                                    :tags:help:org:mode:\n" +
             "* Commonly used tags3:tags:help:org:mode:\n" +
             "* Scheduling\n" +
-            "** TODO Multiple SCHEDULED for a note :multiple:\n" +
+            "** TODO Multiple SCHEDULED for a note                              :multiple:\n" +
             "   SCHEDULED: <2013-01-01>\n" +
             "- State \"DONE\"       from \"TODO\"       [2013-06-22 Sat 14:53]\n" +
             "- State \"DONE\"       from \"TODO\"       [2013-06-22 Sat 14:53]\n" +

--- a/src/test/java/com/orgzly/org/parser/OrgParserTest.java
+++ b/src/test/java/com/orgzly/org/parser/OrgParserTest.java
@@ -45,7 +45,7 @@ public class OrgParserTest extends OrgTestParser {
     @Test
     public void testTodoWithTagScheduledAndContent() throws IOException {
         Assert.assertEquals(
-                "** TODO Multiple SCHEDULED for a note :multiple:\n" +
+                "** TODO Multiple SCHEDULED for a note                              :multiple:\n" +
                 "SCHEDULED: <2013-01-01>\n" +
                 "\n" +
                 "Content.\n\n",
@@ -58,7 +58,7 @@ public class OrgParserTest extends OrgTestParser {
     @Test
     public void testTodoWithHourlyScheduled1() throws IOException {
         Assert.assertEquals(
-                "** TODO Multiple SCHEDULED for a note :multiple:\n" +
+                "** TODO Multiple SCHEDULED for a note                              :multiple:\n" +
                 "SCHEDULED: <2013-01-01 01:00>\n" +
                 "\n" +
                 "Content.\n" +
@@ -72,7 +72,7 @@ public class OrgParserTest extends OrgTestParser {
     @Test
     public void testTodoWithHourlyScheduled2() throws IOException {
         Assert.assertEquals(
-                "** TODO Multiple SCHEDULED for a note :multiple:\n" +
+                "** TODO Multiple SCHEDULED for a note                              :multiple:\n" +
                 "SCHEDULED: <2013-01-01 00:00>\n" +
                 "\n" +
                 "Content.\n" +
@@ -85,19 +85,19 @@ public class OrgParserTest extends OrgTestParser {
 
     @Test
     public void testTodoWithSingleTag() throws IOException {
-        Assert.assertEquals("** TODO Simple todo note :simple:\n",
+        Assert.assertEquals("** TODO Simple todo note                                             :simple:\n",
                 parsed("** TODO Simple todo note :simple:"));
     }
 
     @Test
     public void testTodoWithSingleSpacedOutTag() throws IOException {
-        Assert.assertEquals("** TODO Simple todo note :simple:\n",
+        Assert.assertEquals("** TODO Simple todo note                                             :simple:\n",
                 parsed("** TODO Simple todo note           :simple:"));
     }
 
     @Test
     public void testTagsCharacters1() throws IOException {
-        OrgHead head = parserBuilder.setInput("* Note :سلامی:").build().parse().getHeadsInList().get(0).getHead();
+        OrgHead head = parserBuilder.setInput("* Note                                                               :سلامی:").build().parse().getHeadsInList().get(0).getHead();
 
         Assert.assertEquals(1, head.getTags().size());
         Assert.assertEquals("سلامی", head.getTags().get(0));
@@ -105,7 +105,7 @@ public class OrgParserTest extends OrgTestParser {
 
     @Test
     public void testTagsCharacters2() throws IOException {
-        OrgHead head = parserBuilder.setInput("* Note :Αλφα:").build().parse().getHeadsInList().get(0).getHead();
+        OrgHead head = parserBuilder.setInput("* Note                                                                :Αλφα:").build().parse().getHeadsInList().get(0).getHead();
 
         Assert.assertEquals(1, head.getTags().size());
         Assert.assertEquals("Αλφα", head.getTags().get(0));
@@ -113,7 +113,7 @@ public class OrgParserTest extends OrgTestParser {
 
     @Test
     public void testTagsCharacters3() throws IOException {
-        OrgHead head = parserBuilder.setInput("* Note :Σ:").build().parse().getHeadsInList().get(0).getHead();
+        OrgHead head = parserBuilder.setInput("* Note                                                                   :Σ:").build().parse().getHeadsInList().get(0).getHead();
 
         Assert.assertEquals(1, head.getTags().size());
         Assert.assertEquals("Σ", head.getTags().get(0));
@@ -121,7 +121,7 @@ public class OrgParserTest extends OrgTestParser {
 
     @Test
     public void testTagsCharacters4() throws IOException {
-        OrgHead head = parserBuilder.setInput("* Note :русский:").build().parse().getHeadsInList().get(0).getHead();
+        OrgHead head = parserBuilder.setInput("* Note                                                             :русский:").build().parse().getHeadsInList().get(0).getHead();
 
         Assert.assertEquals(1, head.getTags().size());
         Assert.assertEquals("русский", head.getTags().get(0));
@@ -129,7 +129,7 @@ public class OrgParserTest extends OrgTestParser {
 
     @Test
     public void testTagsCharacters5() throws IOException {
-        OrgHead head = parserBuilder.setInput("* Note :漢語:").build().parse().getHeadsInList().get(0).getHead();
+        OrgHead head = parserBuilder.setInput("* Note                                                                 :漢語:").build().parse().getHeadsInList().get(0).getHead();
 
         Assert.assertEquals(1, head.getTags().size());
         Assert.assertEquals("漢語", head.getTags().get(0));
@@ -137,7 +137,7 @@ public class OrgParserTest extends OrgTestParser {
 
     @Test
     public void testTagsCharactersA() throws IOException {
-        OrgHead head = parserBuilder.setInput("* Note :0aZ_#@%:").build().parse().getHeadsInList().get(0).getHead();
+        OrgHead head = parserBuilder.setInput("* Note                                                             :0aZ_#@%:").build().parse().getHeadsInList().get(0).getHead();
 
         Assert.assertEquals(1, head.getTags().size());
         Assert.assertEquals("0aZ_#@%", head.getTags().get(0));
@@ -145,14 +145,14 @@ public class OrgParserTest extends OrgTestParser {
 
     @Test
     public void testTagsCharactersB() throws IOException {
-        OrgHead head = parserBuilder.setInput("* Note :ру́сский:Αλφα:Σ:سلامی:漢語:").build().parse().getHeadsInList().get(0).getHead();
+        OrgHead head = parserBuilder.setInput("* Note                                           :ру́сский:Αλφα:Σ:سلامی:漢語:").build().parse().getHeadsInList().get(0).getHead();
 
         Assert.assertEquals(5, head.getTags().size());
     }
 
     @Test
     public void testScheduledAndClosed() throws IOException {
-        Assert.assertEquals("** TODO Multiple SCHEDULED for a note :multiple:\n" +
+        Assert.assertEquals("** TODO Multiple SCHEDULED for a note                              :multiple:\n" +
                             "CLOSED: [2012-12-29 Sat 08:05] DEADLINE: <2012-12-28 Fri> SCHEDULED: <2012-12-27 Thu>\n\n",
                 parsed("** TODO Multiple SCHEDULED for a note :multiple:\n" +
                        "CLOSED: [2012-12-29 Sat 08:05] DEADLINE: <2012-12-28 Fri> SCHEDULED: <2012-12-27 Thu>"));
@@ -161,7 +161,7 @@ public class OrgParserTest extends OrgTestParser {
     @Test
     public void testTodoWithWeekKay() throws IOException {
         Assert.assertEquals(
-                "** TODO Multiple SCHEDULED for a note :multiple:\n"
+                "** TODO Multiple SCHEDULED for a note                              :multiple:\n"
                 + "SCHEDULED: <2013-01-01 Tue>\n" +
                 "\n" +
                 "Content.\n" +
@@ -175,7 +175,7 @@ public class OrgParserTest extends OrgTestParser {
     @Test
     public void testTodoWithoutWeekKay() throws IOException {
         Assert.assertEquals(
-                "** TODO Multiple SCHEDULED for a note :multiple:\n"
+                "** TODO Multiple SCHEDULED for a note                              :multiple:\n"
                 + "SCHEDULED: <2013-01-01>\n" +
                 "\n" +
                 "Content.\n" +
@@ -541,7 +541,7 @@ public class OrgParserTest extends OrgTestParser {
 
     @Test
     public void testRich1() throws IOException {
-        String str = "* TODO Rich markup :tag:\n" +
+        String str = "* TODO Rich markup                                                      :tag:\n" +
                      "  DEADLINE: <2015-02-08 Sun> SCHEDULED: <2015-02-11 Wed +1d>\n" +
                      "  :LOGBOOK:  \n" +
                      "  - Note taken on [2015-02-07 Sat 20:58] \\\\\n" +

--- a/src/test/java/com/orgzly/org/parser/OrgParserTest.java
+++ b/src/test/java/com/orgzly/org/parser/OrgParserTest.java
@@ -627,7 +627,61 @@ public class OrgParserTest extends OrgTestParser {
         Assert.assertEquals(str, parsed(str));
     }
 
+    @Test
+    public void testOrgTagsColumnPositive () throws IOException {
+        String str = "* Note :tag:thisalsoisatag:\n" +
+            "**** Note 2 :tag2:\n\n";
+
+        String expectedStr =
+            "* Note              :tag:thisalsoisatag:\n" +
+            "**** Note 2         :tag2:\n";
+
+        OrgParserSettings settings = new OrgParserSettings();
+        settings.tagsColumn = 20;
+
+        String parsedStr = parsedWithSettings(str, settings);
+        Assert.assertEquals(expectedStr, parsedStr);
+    }
+
+    @Test
+    public void testOrgTagsColumnNegative () throws IOException {
+        String str = "* Note :tag:tag234:\n" +
+            "**** Note 2 :tag2:\n\n";
+
+        String expectedStr =
+            "* Note  :tag:tag234:\n" +
+            "**** Note 2   :tag2:\n";
+
+        OrgParserSettings settings = new OrgParserSettings();
+        settings.tagsColumn = -20;
+
+        String parsedStr = parsedWithSettings(str, settings);
+        Assert.assertEquals(expectedStr, parsedStr);
+    }
+
+    @Test
+    public void testOrgTagsColumnNegativeWithVirtual() throws IOException {
+        String str = "* Note :tag:t2:\n" +
+            "** Note 2 :tag2:\n\n";
+
+        String expectedStr =
+            "* Note      :tag:t2:\n" +
+            "** Note 2  :tag2:\n";
+
+        OrgParserSettings settings = new OrgParserSettings();
+        settings.tagsColumn = -20;
+        settings.orgIndentMode = true;
+        settings.orgIndentIndentationPerLevel = 4;
+
+        String parsedStr = parsedWithSettings(str, settings);
+        Assert.assertEquals(expectedStr, parsedStr);
+    }
+
     private String parsed(String original) throws IOException {
         return parserBuilder.setInput(original).build().parse().toString();
+    }
+
+    private String parsedWithSettings(String original, OrgParserSettings settings) throws IOException {
+        return parserBuilder.setInput(original).build().parse().toString(settings);
     }
 }

--- a/src/test/java/com/orgzly/org/parser/OrgParserTest.java
+++ b/src/test/java/com/orgzly/org/parser/OrgParserTest.java
@@ -45,7 +45,7 @@ public class OrgParserTest extends OrgTestParser {
     @Test
     public void testTodoWithTagScheduledAndContent() throws IOException {
         Assert.assertEquals(
-                "** TODO Multiple SCHEDULED for a note                              :multiple:\n" +
+                "** TODO Multiple SCHEDULED for a note :multiple:\n" +
                 "SCHEDULED: <2013-01-01>\n" +
                 "\n" +
                 "Content.\n\n",
@@ -58,7 +58,7 @@ public class OrgParserTest extends OrgTestParser {
     @Test
     public void testTodoWithHourlyScheduled1() throws IOException {
         Assert.assertEquals(
-                "** TODO Multiple SCHEDULED for a note                              :multiple:\n" +
+                "** TODO Multiple SCHEDULED for a note :multiple:\n" +
                 "SCHEDULED: <2013-01-01 01:00>\n" +
                 "\n" +
                 "Content.\n" +
@@ -72,7 +72,7 @@ public class OrgParserTest extends OrgTestParser {
     @Test
     public void testTodoWithHourlyScheduled2() throws IOException {
         Assert.assertEquals(
-                "** TODO Multiple SCHEDULED for a note                              :multiple:\n" +
+                "** TODO Multiple SCHEDULED for a note :multiple:\n" +
                 "SCHEDULED: <2013-01-01 00:00>\n" +
                 "\n" +
                 "Content.\n" +
@@ -85,19 +85,19 @@ public class OrgParserTest extends OrgTestParser {
 
     @Test
     public void testTodoWithSingleTag() throws IOException {
-        Assert.assertEquals("** TODO Simple todo note                                             :simple:\n",
+        Assert.assertEquals("** TODO Simple todo note :simple:\n",
                 parsed("** TODO Simple todo note :simple:"));
     }
 
     @Test
     public void testTodoWithSingleSpacedOutTag() throws IOException {
-        Assert.assertEquals("** TODO Simple todo note                                             :simple:\n",
+        Assert.assertEquals("** TODO Simple todo note :simple:\n",
                 parsed("** TODO Simple todo note           :simple:"));
     }
 
     @Test
     public void testTagsCharacters1() throws IOException {
-        OrgHead head = parserBuilder.setInput("* Note                                                               :سلامی:").build().parse().getHeadsInList().get(0).getHead();
+        OrgHead head = parserBuilder.setInput("* Note :سلامی:").build().parse().getHeadsInList().get(0).getHead();
 
         Assert.assertEquals(1, head.getTags().size());
         Assert.assertEquals("سلامی", head.getTags().get(0));
@@ -105,7 +105,7 @@ public class OrgParserTest extends OrgTestParser {
 
     @Test
     public void testTagsCharacters2() throws IOException {
-        OrgHead head = parserBuilder.setInput("* Note                                                                :Αλφα:").build().parse().getHeadsInList().get(0).getHead();
+        OrgHead head = parserBuilder.setInput("* Note :Αλφα:").build().parse().getHeadsInList().get(0).getHead();
 
         Assert.assertEquals(1, head.getTags().size());
         Assert.assertEquals("Αλφα", head.getTags().get(0));
@@ -113,7 +113,7 @@ public class OrgParserTest extends OrgTestParser {
 
     @Test
     public void testTagsCharacters3() throws IOException {
-        OrgHead head = parserBuilder.setInput("* Note                                                                   :Σ:").build().parse().getHeadsInList().get(0).getHead();
+        OrgHead head = parserBuilder.setInput("* Note :Σ:").build().parse().getHeadsInList().get(0).getHead();
 
         Assert.assertEquals(1, head.getTags().size());
         Assert.assertEquals("Σ", head.getTags().get(0));
@@ -121,7 +121,7 @@ public class OrgParserTest extends OrgTestParser {
 
     @Test
     public void testTagsCharacters4() throws IOException {
-        OrgHead head = parserBuilder.setInput("* Note                                                             :русский:").build().parse().getHeadsInList().get(0).getHead();
+        OrgHead head = parserBuilder.setInput("* Note :русский:").build().parse().getHeadsInList().get(0).getHead();
 
         Assert.assertEquals(1, head.getTags().size());
         Assert.assertEquals("русский", head.getTags().get(0));
@@ -129,7 +129,7 @@ public class OrgParserTest extends OrgTestParser {
 
     @Test
     public void testTagsCharacters5() throws IOException {
-        OrgHead head = parserBuilder.setInput("* Note                                                                 :漢語:").build().parse().getHeadsInList().get(0).getHead();
+        OrgHead head = parserBuilder.setInput("* Note :漢語:").build().parse().getHeadsInList().get(0).getHead();
 
         Assert.assertEquals(1, head.getTags().size());
         Assert.assertEquals("漢語", head.getTags().get(0));
@@ -137,7 +137,7 @@ public class OrgParserTest extends OrgTestParser {
 
     @Test
     public void testTagsCharactersA() throws IOException {
-        OrgHead head = parserBuilder.setInput("* Note                                                             :0aZ_#@%:").build().parse().getHeadsInList().get(0).getHead();
+        OrgHead head = parserBuilder.setInput("* Note :0aZ_#@%:").build().parse().getHeadsInList().get(0).getHead();
 
         Assert.assertEquals(1, head.getTags().size());
         Assert.assertEquals("0aZ_#@%", head.getTags().get(0));
@@ -145,14 +145,14 @@ public class OrgParserTest extends OrgTestParser {
 
     @Test
     public void testTagsCharactersB() throws IOException {
-        OrgHead head = parserBuilder.setInput("* Note                                           :ру́сский:Αλφα:Σ:سلامی:漢語:").build().parse().getHeadsInList().get(0).getHead();
+        OrgHead head = parserBuilder.setInput("* Note :ру́сский:Αλφα:Σ:سلامی:漢語:").build().parse().getHeadsInList().get(0).getHead();
 
         Assert.assertEquals(5, head.getTags().size());
     }
 
     @Test
     public void testScheduledAndClosed() throws IOException {
-        Assert.assertEquals("** TODO Multiple SCHEDULED for a note                              :multiple:\n" +
+        Assert.assertEquals("** TODO Multiple SCHEDULED for a note :multiple:\n" +
                             "CLOSED: [2012-12-29 Sat 08:05] DEADLINE: <2012-12-28 Fri> SCHEDULED: <2012-12-27 Thu>\n\n",
                 parsed("** TODO Multiple SCHEDULED for a note :multiple:\n" +
                        "CLOSED: [2012-12-29 Sat 08:05] DEADLINE: <2012-12-28 Fri> SCHEDULED: <2012-12-27 Thu>"));
@@ -161,7 +161,7 @@ public class OrgParserTest extends OrgTestParser {
     @Test
     public void testTodoWithWeekKay() throws IOException {
         Assert.assertEquals(
-                "** TODO Multiple SCHEDULED for a note                              :multiple:\n"
+                "** TODO Multiple SCHEDULED for a note :multiple:\n"
                 + "SCHEDULED: <2013-01-01 Tue>\n" +
                 "\n" +
                 "Content.\n" +
@@ -175,7 +175,7 @@ public class OrgParserTest extends OrgTestParser {
     @Test
     public void testTodoWithoutWeekKay() throws IOException {
         Assert.assertEquals(
-                "** TODO Multiple SCHEDULED for a note                              :multiple:\n"
+                "** TODO Multiple SCHEDULED for a note :multiple:\n"
                 + "SCHEDULED: <2013-01-01>\n" +
                 "\n" +
                 "Content.\n" +
@@ -541,7 +541,7 @@ public class OrgParserTest extends OrgTestParser {
 
     @Test
     public void testRich1() throws IOException {
-        String str = "* TODO Rich markup                                                      :tag:\n" +
+        String str = "* TODO Rich markup :tag:\n" +
                      "  DEADLINE: <2015-02-08 Sun> SCHEDULED: <2015-02-11 Wed +1d>\n" +
                      "  :LOGBOOK:  \n" +
                      "  - Note taken on [2015-02-07 Sat 20:58] \\\\\n" +


### PR DESCRIPTION
Orgzly and Emacs re-aligning the tags all the time made keeping my notes in source control bothersome. (I had to resolve lots of conflicts.) 

Now, setting OrgParserSettings.tagsColumn to -77 matches org-mode's default behaviour. Setting it to 0 matches the previous behavior.

I changed the default to mimic Emacs (tagsColumn=-77), but I don't mind changing it back to 0 if you prefer, so the default behavior doesn't change.

if this PR gets accepted, I'll look at exposing this setting in Orgzly's settings menu too.