### PR TITLE
Parse all plain timestamps in a heading

### DIFF
--- a/src/main/java/com/orgzly/org/OrgContent.java
+++ b/src/main/java/com/orgzly/org/OrgContent.java
@@ -17,15 +17,6 @@ public class OrgContent {
     }
 
     /**
-     * Content (body). Text after the heading.
-     *
-     * @return content
-     */
-    public String toString() {
-        return value.toString();
-    }
-
-    /**
      * @return {@code false} if there is a text below heading, {@code true} otherwise
      */
     public boolean isEmpty() {
@@ -40,6 +31,13 @@ public class OrgContent {
 
     public void append(String s) {
         value.append(s);
+    }
+
+    /**
+     * @return the content text
+     */
+    public String toString() {
+        return value.toString();
     }
 
     /**

--- a/src/main/java/com/orgzly/org/OrgContent.java
+++ b/src/main/java/com/orgzly/org/OrgContent.java
@@ -4,6 +4,7 @@ import com.orgzly.org.datetime.OrgRange;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
 
 /**
  * Text below a heading.
@@ -24,13 +25,14 @@ public class OrgContent {
     }
 
     public void set(String value) {
-        if (value != null) {
-            this.value = new StringBuilder(value);
-        }
+        this.value = new StringBuilder(value);
+        timestamps = null;
+        reparse();
     }
 
     public void append(String s) {
         value.append(s);
+        parseLine(s);
     }
 
     /**
@@ -61,6 +63,22 @@ public class OrgContent {
         }
 
         timestamps.add(timestamp);
+    }
+
+    /** Parse all plain timestamps in this line and add them to the timestamps list. */
+    public void parseLine(String line) {
+        Matcher m = OrgPatterns.DT_OR_RANGE_P.matcher(line);
+        while (m.find()) {
+            addTimestamp(OrgRange.parse(m.group()));
+        }
+    }
+
+    /** Parse the whole content to rebuild the timestamps list. */
+    public void reparse() {
+        String content = toString();
+        for (String line: content.split("\n")) {
+            parseLine(line);
+        }
     }
 
 }

--- a/src/main/java/com/orgzly/org/OrgContent.java
+++ b/src/main/java/com/orgzly/org/OrgContent.java
@@ -21,7 +21,8 @@ public class OrgContent {
     }
 
     /**
-     * @return {@code false} if there is a text below heading, {@code true} otherwise
+     * @return {@code false} if there is a text below heading, {@code true}
+     * otherwise
      */
     public boolean isEmpty() {
         return value.length() == 0;
@@ -58,7 +59,13 @@ public class OrgContent {
     }
 
     public boolean hasTimestamps() {
-        return timestamps != null && !timestamps.isEmpty();
+        if (timestamps == null) {
+            return false;
+        }
+        if (dirty) {
+            reparse();
+        }
+        return !timestamps.isEmpty();
     }
 
     /** Parse all plain timestamps in this content and rebuild the timestamps list. */

--- a/src/main/java/com/orgzly/org/OrgContent.java
+++ b/src/main/java/com/orgzly/org/OrgContent.java
@@ -1,0 +1,68 @@
+package com.orgzly.org;
+
+import com.orgzly.org.datetime.OrgRange;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Text below a heading.
+ */
+public class OrgContent {
+    StringBuilder value;
+    private List<OrgRange> timestamps;
+
+    public OrgContent() {
+        this.value = new StringBuilder();
+    }
+
+    /**
+     * Content (body). Text after the heading.
+     *
+     * @return content
+     */
+    public String toString() {
+        return value.toString();
+    }
+
+    /**
+     * @return {@code false} if there is a text below heading, {@code true} otherwise
+     */
+    public boolean isEmpty() {
+        return value.length() == 0;
+    }
+
+    public void set(String value) {
+        if (value != null) {
+            this.value = new StringBuilder(value);
+        }
+    }
+
+    public void append(String s) {
+        value.append(s);
+    }
+
+    /**
+     * Plain timestamps.
+     */
+    public List<OrgRange> getTimestamps() {
+        if (timestamps == null) {
+            return new ArrayList<>();
+        } else {
+            return timestamps;
+        }
+    }
+
+    public boolean hasTimestamps() {
+        return timestamps != null && !timestamps.isEmpty();
+    }
+
+    public void addTimestamp(OrgRange timestamp) {
+        if (timestamps == null) {
+            timestamps = new ArrayList<>();
+        }
+
+        timestamps.add(timestamp);
+    }
+
+}

--- a/src/main/java/com/orgzly/org/OrgContent.java
+++ b/src/main/java/com/orgzly/org/OrgContent.java
@@ -29,8 +29,13 @@ public class OrgContent {
     }
 
     public void set(String value) {
-        this.value = new StringBuilder(value);
-        dirty = true;
+        if (value == null) {
+            this.value = new StringBuilder("");
+        }
+        else {
+            this.value = new StringBuilder(value);
+            dirty = true;
+        }
     }
 
     public void append(String s) {
@@ -46,7 +51,7 @@ public class OrgContent {
     }
 
     /**
-     * Plain timestamps.
+     * @return the list of plain timestamps in this content text
      */
     public List<OrgRange> getTimestamps() {
         if (timestamps == null) {

--- a/src/main/java/com/orgzly/org/OrgHead.java
+++ b/src/main/java/com/orgzly/org/OrgHead.java
@@ -96,7 +96,7 @@ public class OrgHead {
      *
      * @return the content object
      */
-    public OrgContent getContent() {
+    public OrgContent getContentObject() {
         if (content == null) {
             content = new OrgContent();
         }
@@ -108,8 +108,8 @@ public class OrgHead {
      *
      * @return the content text
      */
-    public String getContentString() {
-        return getContent().toString();
+    public String getContent() {
+        return getContentObject().toString();
     }
 
     /**

--- a/src/main/java/com/orgzly/org/OrgHead.java
+++ b/src/main/java/com/orgzly/org/OrgHead.java
@@ -94,13 +94,22 @@ public class OrgHead {
     /**
      * Content (body). Text after the heading.
      *
-     * @return content
+     * @return the content object
      */
     public OrgContent getContent() {
         if (content == null) {
             content = new OrgContent();
         }
         return content;
+    }
+
+    /**
+     * Content (body). Text after the heading.
+     *
+     * @return the content text
+     */
+    public String getContentString() {
+        return getContent().toString();
     }
 
     /**

--- a/src/main/java/com/orgzly/org/OrgHead.java
+++ b/src/main/java/com/orgzly/org/OrgHead.java
@@ -22,7 +22,6 @@ public class OrgHead {
     private OrgRange scheduled;
     private OrgRange deadline;
     private OrgRange closed;
-    private List<OrgRange> timestamps;
 
     private OrgRange clock; // TODO: Create OrgClock with elapsed time?
 
@@ -30,7 +29,7 @@ public class OrgHead {
 
     private List<String> logbook;
 
-    private StringBuilder content;
+    private OrgContent content;
 
     /**
      * Creates an empty heading.
@@ -41,7 +40,6 @@ public class OrgHead {
 
     public OrgHead(String str) {
         this.title = str;
-        this.content = new StringBuilder();
     }
 
     /**
@@ -98,26 +96,31 @@ public class OrgHead {
      *
      * @return content
      */
-    public String getContent() {
-        return content.toString();
+    public OrgContent getContent() {
+        if (content == null) {
+            content = new OrgContent();
+        }
+        return content;
     }
 
     /**
      * @return {@code true} if there is a text below heading, {@code false} otherwise
      */
     public boolean hasContent() {
-        return content.length() > 0;
+        return content != null && !content.isEmpty();
     }
 
-    public void setContent(String content) {
-        if (content != null) {
-            this.content = new StringBuilder(content);
-        } else {
-            this.content = new StringBuilder("");
+    public void setContent(String s) {
+        if (content == null) {
+            content = new OrgContent();
         }
+        content.set(s);
     }
 
     public void appendContent(String s) {
+        if (content == null) {
+            content = new OrgContent();
+        }
         content.append(s);
     }
 
@@ -179,29 +182,6 @@ public class OrgHead {
 
     public void setDeadline(OrgRange time) {
         deadline = time;
-    }
-
-    /**
-     * Plain timestamps.
-     */
-    public List<OrgRange> getTimestamps() {
-        if (timestamps == null) {
-            return new ArrayList<>();
-        } else {
-            return timestamps;
-        }
-    }
-
-    public boolean hasTimestamps() {
-        return timestamps != null && !timestamps.isEmpty();
-    }
-
-    public void addTimestamp(OrgRange timestamp) {
-        if (timestamps == null) {
-            timestamps = new ArrayList<>();
-        }
-
-        timestamps.add(timestamp);
     }
 
     /**

--- a/src/main/java/com/orgzly/org/OrgHead.java
+++ b/src/main/java/com/orgzly/org/OrgHead.java
@@ -22,6 +22,7 @@ public class OrgHead {
     private OrgRange scheduled;
     private OrgRange deadline;
     private OrgRange closed;
+    private List<OrgRange> timestamps;
 
     private OrgRange clock; // TODO: Create OrgClock with elapsed time?
 
@@ -178,6 +179,29 @@ public class OrgHead {
 
     public void setDeadline(OrgRange time) {
         deadline = time;
+    }
+
+    /**
+     * Plain timestamps.
+     */
+    public List<OrgRange> getTimestamps() {
+        if (timestamps == null) {
+            return new ArrayList<>();
+        } else {
+            return timestamps;
+        }
+    }
+
+    public boolean hasTimestamps() {
+        return timestamps != null && !timestamps.isEmpty();
+    }
+
+    public void addTimestamp(OrgRange timestamp) {
+        if (timestamps == null) {
+            timestamps = new ArrayList<>();
+        }
+
+        timestamps.add(timestamp);
     }
 
     /**

--- a/src/main/java/com/orgzly/org/parser/OrgParserWriter.java
+++ b/src/main/java/com/orgzly/org/parser/OrgParserWriter.java
@@ -212,14 +212,14 @@ public class OrgParserWriter {
              * unless it starts with following strings.
              * Until LOGBOOK and CLOCK support is added.
              */
-            String content = head.getContentString().trim();
+            String content = head.getContent().trim();
             if (!content.startsWith(":LOGBOOK:") && !content.startsWith("CLOCK: ") && !isLogNoteHeading(content)) {
                 if (settings.separateHeaderAndContentWithNewLine) {
                     s.append("\n");
                 }
             }
 
-            s.append(head.getContentString());
+            s.append(head.getContent());
             s.append("\n");
 
             if (settings.separateNotesWithNewLine == OrgParserSettings.SeparateNotesWithNewLine.MULTI_LINE_NOTES_ONLY) {

--- a/src/main/java/com/orgzly/org/parser/OrgParserWriter.java
+++ b/src/main/java/com/orgzly/org/parser/OrgParserWriter.java
@@ -212,14 +212,14 @@ public class OrgParserWriter {
              * unless it starts with following strings.
              * Until LOGBOOK and CLOCK support is added.
              */
-            String content = head.getContent().toString().trim();
+            String content = head.getContentString().trim();
             if (!content.startsWith(":LOGBOOK:") && !content.startsWith("CLOCK: ") && !isLogNoteHeading(content)) {
                 if (settings.separateHeaderAndContentWithNewLine) {
                     s.append("\n");
                 }
             }
 
-            s.append(head.getContent());
+            s.append(head.getContentString());
             s.append("\n");
 
             if (settings.separateNotesWithNewLine == OrgParserSettings.SeparateNotesWithNewLine.MULTI_LINE_NOTES_ONLY) {

--- a/src/main/java/com/orgzly/org/parser/OrgParserWriter.java
+++ b/src/main/java/com/orgzly/org/parser/OrgParserWriter.java
@@ -212,7 +212,7 @@ public class OrgParserWriter {
              * unless it starts with following strings.
              * Until LOGBOOK and CLOCK support is added.
              */
-            String content = head.getContent().trim();
+            String content = head.getContent().toString().trim();
             if (!content.startsWith(":LOGBOOK:") && !content.startsWith("CLOCK: ") && !isLogNoteHeading(content)) {
                 if (settings.separateHeaderAndContentWithNewLine) {
                     s.append("\n");

--- a/src/main/java/com/orgzly/org/parser/OrgSaxyParser.java
+++ b/src/main/java/com/orgzly/org/parser/OrgSaxyParser.java
@@ -288,7 +288,7 @@ class OrgSaxyParser extends OrgParser {
      * Called before every announcement.
      */
     private void trimContent(OrgHead head) {
-        head.setContent(OrgStringUtils.trimLines(head.getContentString()));
+        head.setContent(OrgStringUtils.trimLines(head.getContent()));
     }
 
     /**

--- a/src/main/java/com/orgzly/org/parser/OrgSaxyParser.java
+++ b/src/main/java/com/orgzly/org/parser/OrgSaxyParser.java
@@ -200,12 +200,6 @@ class OrgSaxyParser extends OrgParser {
                         }
                     }
 
-                    /* Parse all plain timestamps in this line */
-                    Matcher m = OrgPatterns.DT_OR_RANGE_P.matcher(line);
-                    while (m.find()) {
-                        currentElement.getHead().getContent().addTimestamp(OrgRange.parse(m.group()));
-                    }
-
                     currentElement.getHead().appendContent(line);
                     currentElement.getHead().appendContent("\n");
 

--- a/src/main/java/com/orgzly/org/parser/OrgSaxyParser.java
+++ b/src/main/java/com/orgzly/org/parser/OrgSaxyParser.java
@@ -203,7 +203,7 @@ class OrgSaxyParser extends OrgParser {
                     /* Parse all plain timestamps in this line */
                     Matcher m = OrgPatterns.DT_OR_RANGE_P.matcher(line);
                     while (m.find()) {
-                        currentElement.getHead().addTimestamp(OrgRange.parse(m.group()));
+                        currentElement.getHead().getContent().addTimestamp(OrgRange.parse(m.group()));
                     }
 
                     currentElement.getHead().appendContent(line);
@@ -294,7 +294,7 @@ class OrgSaxyParser extends OrgParser {
      * Called before every announcement.
      */
     private void trimContent(OrgHead head) {
-        head.setContent(OrgStringUtils.trimLines(head.getContent()));
+        head.setContent(OrgStringUtils.trimLines(head.getContent().toString()));
     }
 
     /**

--- a/src/main/java/com/orgzly/org/parser/OrgSaxyParser.java
+++ b/src/main/java/com/orgzly/org/parser/OrgSaxyParser.java
@@ -198,7 +198,12 @@ class OrgSaxyParser extends OrgParser {
                             // There could still be heading-bound lines.
                             continue;
                         }
+                    }
 
+                    /* Parse all plain timestamps in this line */
+                    Matcher m = OrgPatterns.DT_OR_RANGE_P.matcher(line);
+                    while (m.find()) {
+                        currentElement.getHead().addTimestamp(OrgRange.parse(m.group()));
                     }
 
                     currentElement.getHead().appendContent(line);

--- a/src/main/java/com/orgzly/org/parser/OrgSaxyParser.java
+++ b/src/main/java/com/orgzly/org/parser/OrgSaxyParser.java
@@ -294,7 +294,7 @@ class OrgSaxyParser extends OrgParser {
      * Called before every announcement.
      */
     private void trimContent(OrgHead head) {
-        head.setContent(OrgStringUtils.trimLines(head.getContent().toString()));
+        head.setContent(OrgStringUtils.trimLines(head.getContentString()));
     }
 
     /**

--- a/src/test/java/com/orgzly/org/OrgContentTest.java
+++ b/src/test/java/com/orgzly/org/OrgContentTest.java
@@ -30,4 +30,11 @@ public class OrgContentTest {
         Assert.assertEquals(1, o.getTimestamps().size());
         Assert.assertEquals("<2001-01-01 10:10>", o.getTimestamps().get(0).toString());
     }
+
+    @Test
+    public void testEmptyContent() {
+        OrgContent o = new OrgContent();
+        Assert.assertEquals(0, o.getTimestamps().size());
+        Assert.assertFalse(o.hasTimestamps());
+    }
 }

--- a/src/test/java/com/orgzly/org/OrgContentTest.java
+++ b/src/test/java/com/orgzly/org/OrgContentTest.java
@@ -14,6 +14,15 @@ public class OrgContentTest {
     }
 
     @Test
+    public void testTimestampMultiline() {
+        OrgContent o = new OrgContent();
+        o.append("<2000-01-01 10:10>\n<2001-01-01 10:10>");
+        Assert.assertEquals(2, o.getTimestamps().size());
+        Assert.assertEquals("<2000-01-01 10:10>", o.getTimestamps().get(0).toString());
+        Assert.assertEquals("<2001-01-01 10:10>", o.getTimestamps().get(1).toString());
+    }
+
+    @Test
     public void testReparse() {
         OrgContent o = new OrgContent();
         o.append("<2000-01-01 10:10>");

--- a/src/test/java/com/orgzly/org/OrgContentTest.java
+++ b/src/test/java/com/orgzly/org/OrgContentTest.java
@@ -1,0 +1,24 @@
+package com.orgzly.org;
+
+import com.orgzly.org.OrgContent;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class OrgContentTest {
+    @Test
+    public void testTimestamp() {
+        OrgContent o = new OrgContent();
+        o.append("<2000-01-01 10:10>");
+        Assert.assertEquals(1, o.getTimestamps().size());
+        Assert.assertEquals("<2000-01-01 10:10>", o.getTimestamps().get(0).toString());
+    }
+
+    @Test
+    public void testReparse() {
+        OrgContent o = new OrgContent();
+        o.append("<2000-01-01 10:10>");
+        o.set("\n\n<2001-01-01 10:10>");
+        Assert.assertEquals(1, o.getTimestamps().size());
+        Assert.assertEquals("<2001-01-01 10:10>", o.getTimestamps().get(0).toString());
+    }
+}

--- a/src/test/java/com/orgzly/org/parser/OrgParserTest.java
+++ b/src/test/java/com/orgzly/org/parser/OrgParserTest.java
@@ -1,10 +1,11 @@
 package com.orgzly.org.parser;
 
-
+import java.util.List;
 import com.orgzly.org.OrgFileSettings;
 import com.orgzly.org.OrgHead;
 import com.orgzly.org.OrgProperty;
 import com.orgzly.org.OrgTestParser;
+import com.orgzly.org.datetime.OrgRange;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -675,6 +676,37 @@ public class OrgParserTest extends OrgTestParser {
 
         String parsedStr = parsed(str, settings);
         Assert.assertEquals(expectedStr, parsedStr);
+    }
+
+    @Test
+    public void testPlainTimestamps() throws IOException {
+        String str = "* Node\n" +
+            "CLOSED: [2012-12-29 Sat 08:05] DEADLINE: <2012-12-28 Fri> SCHEDULED: <2012-12-27 Thu>\n" +
+            "<2018-01-15 Mon> some text between timestamps <2018-01-16 Tue>\n" +
+            "Blabla some other text in front <2018-01-17 Wed> text after\n" +
+            "\n\n" +
+            "[2018-01-18 Thu]\n\n";
+
+        OrgParsedFile file = parserBuilder.setInput(str).build().parse();
+
+        List<OrgRange> timestamps = file.getHeadsInList().get(0).getHead().getTimestamps();
+        Assert.assertEquals(4, timestamps.size());
+        Assert.assertEquals("<2018-01-15 Mon>", timestamps.get(0).toString());
+        Assert.assertEquals("<2018-01-16 Tue>", timestamps.get(1).toString());
+        Assert.assertEquals("<2018-01-17 Wed>", timestamps.get(2).toString());
+        Assert.assertEquals("[2018-01-18 Thu]", timestamps.get(3).toString());
+    }
+
+    @Test
+    public void testPlainTimestampsNoHeader() throws IOException {
+        String str = "* Node\n" +
+            "<2018-01-15 Mon>\n";
+
+        OrgParsedFile file = parserBuilder.setInput(str).build().parse();
+
+        List<OrgRange> timestamps = file.getHeadsInList().get(0).getHead().getTimestamps();
+        Assert.assertEquals(1, timestamps.size());
+        Assert.assertEquals("<2018-01-15 Mon>", timestamps.get(0).toString());
     }
 
     private String parsed(String original) throws IOException {

--- a/src/test/java/com/orgzly/org/parser/OrgParserTest.java
+++ b/src/test/java/com/orgzly/org/parser/OrgParserTest.java
@@ -689,7 +689,7 @@ public class OrgParserTest extends OrgTestParser {
 
         OrgParsedFile file = parserBuilder.setInput(str).build().parse();
 
-        List<OrgRange> timestamps = file.getHeadsInList().get(0).getHead().getContent().getTimestamps();
+        List<OrgRange> timestamps = file.getHeadsInList().get(0).getHead().getContentObject().getTimestamps();
         Assert.assertEquals(4, timestamps.size());
         Assert.assertEquals("<2018-01-15 Mon>", timestamps.get(0).toString());
         Assert.assertEquals("<2018-01-16 Tue>", timestamps.get(1).toString());
@@ -704,7 +704,7 @@ public class OrgParserTest extends OrgTestParser {
 
         OrgParsedFile file = parserBuilder.setInput(str).build().parse();
 
-        List<OrgRange> timestamps = file.getHeadsInList().get(0).getHead().getContent().getTimestamps();
+        List<OrgRange> timestamps = file.getHeadsInList().get(0).getHead().getContentObject().getTimestamps();
         Assert.assertEquals(1, timestamps.size());
         Assert.assertEquals("<2018-01-15 Mon>", timestamps.get(0).toString());
     }

--- a/src/test/java/com/orgzly/org/parser/OrgParserTest.java
+++ b/src/test/java/com/orgzly/org/parser/OrgParserTest.java
@@ -689,7 +689,7 @@ public class OrgParserTest extends OrgTestParser {
 
         OrgParsedFile file = parserBuilder.setInput(str).build().parse();
 
-        List<OrgRange> timestamps = file.getHeadsInList().get(0).getHead().getTimestamps();
+        List<OrgRange> timestamps = file.getHeadsInList().get(0).getHead().getContent().getTimestamps();
         Assert.assertEquals(4, timestamps.size());
         Assert.assertEquals("<2018-01-15 Mon>", timestamps.get(0).toString());
         Assert.assertEquals("<2018-01-16 Tue>", timestamps.get(1).toString());
@@ -704,7 +704,7 @@ public class OrgParserTest extends OrgTestParser {
 
         OrgParsedFile file = parserBuilder.setInput(str).build().parse();
 
-        List<OrgRange> timestamps = file.getHeadsInList().get(0).getHead().getTimestamps();
+        List<OrgRange> timestamps = file.getHeadsInList().get(0).getHead().getContent().getTimestamps();
         Assert.assertEquals(1, timestamps.size());
         Assert.assertEquals("<2018-01-15 Mon>", timestamps.get(0).toString());
     }


### PR DESCRIPTION
Previously, plain timestamps (active or inactive) in a note content were
ignored.  The only timestamps we parsed were the scheduled, deadline, or closed
ones in the "header" of a heading.

This commit adds `timestamps`, a list of OrgRange in OrgHead, and modifies
`OrgSaxyParser` to collect plain timestamps.

This commit also adds tests to make sure plain timestamps are collected
correctly.

We assume that we do not care about plain timestamps occurring in a heading's
"header".

I believe this is the one piece of the puzzle in fixing orgzly/orgzly-android/issues/76