### PR TITLE
Use maven-publish plugin for publishing to local maven repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'signing'
+apply plugin: 'maven-publish'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Provides `publishToMavenLocal` Gradle task, useful to test out the library locally.