### PR TITLE
Parse all the #+KEYWORD: VALUE settings not just TITLE

### DIFF
--- a/src/main/java/com/orgzly/org/OrgFileSettings.java
+++ b/src/main/java/com/orgzly/org/OrgFileSettings.java
@@ -36,7 +36,7 @@ public class OrgFileSettings {
     }
 
     public void setTitle(String title) {
-        if (getTitle() != title) {
+        if (title != null && getTitle() != title) {
             addKeywordSetting(TITLE, title);
         }
     }

--- a/src/main/java/com/orgzly/org/OrgFileSettings.java
+++ b/src/main/java/com/orgzly/org/OrgFileSettings.java
@@ -3,18 +3,26 @@ package com.orgzly.org;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.regex.Matcher;
 
 /**
  * In-buffer settings.
  * http://orgmode.org/manual/In_002dbuffer-settings.html
  */
 public class OrgFileSettings {
-    public static final String TITLE = "#+TITLE:";
+    public static final String TITLE = "TITLE";
 //    public static final String FILE_TAGS = "#+FILETAGS:";
 
+    private HashMap<String, List<String>> keywords;
     private String title;
 //    private List<String> fileTags = new ArrayList<>();
 
+    public OrgFileSettings() {
+        keywords = new HashMap<String, List<String>>();
+    }
 
     /**
      * Are planning, property drawers etc. indented with spaced or not.
@@ -24,11 +32,13 @@ public class OrgFileSettings {
     private boolean indented;
 
     public String getTitle() {
-        return title;
+        return getLastKeywordValue(TITLE);
     }
 
     public void setTitle(String title) {
-        this.title = title;
+        if (getTitle() != title) {
+            addKeywordSetting(TITLE, title);
+        }
     }
 
     public boolean isIndented() {
@@ -48,22 +58,40 @@ public class OrgFileSettings {
     public boolean parseLine(String line) {
         boolean settingFound = false;
 
-        if (line.startsWith(TITLE)) {
-            String val = line.substring(TITLE.length()).trim();
-
-            if (val.length() > 0) {
-                setTitle(val);
-            }
-
+        Matcher matcher = OrgPatterns.KEYWORD_VALUE.matcher(line);
+        if (matcher.matches()) {
+            addKeywordSetting(matcher.group(1), matcher.group(2));
             settingFound = true;
         }
 
         return settingFound;
     }
 
+    public List<String> getKeywordValues(String keyword) {
+        if (!keywords.containsKey(keyword))
+            return null;
+        return keywords.get(keyword);
+    }
+
+    public String getLastKeywordValue(String keyword) {
+        List<String> values = getKeywordValues(keyword);
+        if (values == null || values.isEmpty())
+            return null;
+        return values.get(values.size() - 1);
+    }
+
+    private void addKeywordSetting(String keyword, String value) {
+        if (!keywords.containsKey(keyword)) {
+            keywords.put(keyword, new ArrayList<String>());
+        }
+        if (!value.isEmpty()) {
+            keywords.get(keyword).add(value);
+        }
+    }
 
     public static OrgFileSettings fromPreface(String preface) {
         OrgFileSettings settings = new OrgFileSettings();
+
 
         BufferedReader reader = new BufferedReader(new StringReader(preface));
 

--- a/src/main/java/com/orgzly/org/OrgFileSettings.java
+++ b/src/main/java/com/orgzly/org/OrgFileSettings.java
@@ -36,7 +36,7 @@ public class OrgFileSettings {
     }
 
     public void setTitle(String title) {
-        if (title != null && getTitle() != title) {
+        if (title != null && !title.equals(getTitle())) {
             addKeywordSetting(TITLE, title);
         }
     }

--- a/src/main/java/com/orgzly/org/OrgPatterns.java
+++ b/src/main/java/com/orgzly/org/OrgPatterns.java
@@ -42,4 +42,15 @@ public class OrgPatterns {
     public static final Pattern HEAD_TAGS_P = Pattern.compile("^(.*)\\s+:(\\S+):\\s*$");
 
     public static final Pattern PROPERTY = Pattern.compile("^:([^:\\s]+):\\s+(.*)\\s*$");
+
+    /*
+    https://orgmode.org/manual/In_002dbuffer-settings.html
+
+    "In-buffer settings start with ‘#+’, followed by a keyword, a colon,
+    and then a word for each setting. Org accepts multiple settings on the same line.
+    Org also accepts multiple lines for a keyword."
+
+    Here we don't allow multiple settings per line for now.
+     */
+    public static final Pattern KEYWORD_VALUE = Pattern.compile("^#\\+([A-Za-z0-9_]+):\\s*(.*)$");
 }

--- a/src/test/java/com/orgzly/org/parser/OrgParserTest.java
+++ b/src/test/java/com/orgzly/org/parser/OrgParserTest.java
@@ -531,10 +531,21 @@ public class OrgParserTest extends OrgTestParser {
 
     @Test
     public void testFileSettingsTitle() throws IOException {
-        OrgParsedFile file = parserBuilder.setInput(OrgFileSettings.TITLE + " Org Title\n\n* TODO Note\n").build().parse();
+        OrgParsedFile file = parserBuilder.setInput("#+TITLE: Org Title\n\n* TODO Note\n").build().parse();
         Assert.assertNotNull(file.getFile().getSettings());
         Assert.assertNotNull(file.getFile().getSettings().getTitle());
         Assert.assertEquals("Org Title", file.getFile().getSettings().getTitle());
+    }
+    @Test
+    public void testFileSettingsKeywords() throws IOException {
+        OrgParsedFile file = parserBuilder.setInput("#+TITLE: Wrong title\n#+NEWKEYWORD:\n#+TITLE: Org Title\n\n* TODO Note\n").build().parse();
+        Assert.assertNotNull(file.getFile().getSettings());
+        Assert.assertNotNull(file.getFile().getSettings().getTitle());
+        Assert.assertEquals("Org Title", file.getFile().getSettings().getTitle());
+        String[] values = {"Wrong title", "Org Title"};
+        Assert.assertArrayEquals(file.getFile().getSettings().getKeywordValues(OrgFileSettings.TITLE).toArray(), values);
+        Assert.assertNull(file.getFile().getSettings().getLastKeywordValue("NEWKEYWORD"));
+        Assert.assertTrue(file.getFile().getSettings().getKeywordValues("NEWKEYWORD").isEmpty());
     }
 
     @Test

--- a/src/test/java/com/orgzly/org/parser/OrgParserTest.java
+++ b/src/test/java/com/orgzly/org/parser/OrgParserTest.java
@@ -543,7 +543,7 @@ public class OrgParserTest extends OrgTestParser {
         Assert.assertNotNull(file.getFile().getSettings().getTitle());
         Assert.assertEquals("Org Title", file.getFile().getSettings().getTitle());
         String[] values = {"Wrong title", "Org Title"};
-        Assert.assertArrayEquals(file.getFile().getSettings().getKeywordValues(OrgFileSettings.TITLE).toArray(), values);
+        Assert.assertArrayEquals(values, file.getFile().getSettings().getKeywordValues(OrgFileSettings.TITLE).toArray());
         Assert.assertNull(file.getFile().getSettings().getLastKeywordValue("NEWKEYWORD"));
         Assert.assertTrue(file.getFile().getSettings().getKeywordValues("NEWKEYWORD").isEmpty());
     }


### PR DESCRIPTION
This lets OrgFileSettings read all #+KEYWORD values.

I thought we could use this to give the user more control over notebook level settings, and give Orgzly somewhere to persist these settings.

E.g. for Direct Share in https://github.com/orgzly/orgzly-android/pull/400 we could enable this just for books with `#+ORGZLY_DIRECT_SHARE: 1`.
