### PR TITLE
Allow escaped spaces in ArrayListSpaceSeperated 

### DIFF
--- a/src/main/java/com/orgzly/org/utils/ArrayListSpaceSeparated.java
+++ b/src/main/java/com/orgzly/org/utils/ArrayListSpaceSeparated.java
@@ -13,7 +13,7 @@ public class ArrayListSpaceSeparated extends ArrayList<String> {
 
     public ArrayListSpaceSeparated(String str) {
         for (String s: str.split(DELIMITER)) {
-            String st = s.trim();
+            String st = s.trim().replace("\s", " ").replace("\ ", "\s");
             if (st.length() > 0) {
                 add(st);
             }
@@ -21,6 +21,10 @@ public class ArrayListSpaceSeparated extends ArrayList<String> {
     }
 
     public String toString() {
-        return OrgStringUtils.join(this, DELIMITER);
+        String str = "";
+        for (String s: this) {
+            str += s.replace("\s", "\\s").replace(" ", "\s") + " ";
+        }
+        return str.substring(0, str.length() - 1);
     }
 }

--- a/src/main/java/com/orgzly/org/utils/ArrayListSpaceSeparated.java
+++ b/src/main/java/com/orgzly/org/utils/ArrayListSpaceSeparated.java
@@ -13,7 +13,7 @@ public class ArrayListSpaceSeparated extends ArrayList<String> {
 
     public ArrayListSpaceSeparated(String str) {
         for (String s: str.split(DELIMITER)) {
-            String st = s.trim().replace("\s", " ").replace("\ ", "\s");
+            String st = s.trim().replace("\\s", " ").replace("\\ ", "\\s");
             if (st.length() > 0) {
                 add(st);
             }
@@ -23,7 +23,7 @@ public class ArrayListSpaceSeparated extends ArrayList<String> {
     public String toString() {
         String str = "";
         for (String s: this) {
-            str += s.replace("\s", "\\s").replace(" ", "\s") + " ";
+            str += s.replace("\\s", "\\\\s").replace(" ", "\\s") + " ";
         }
         return str.substring(0, str.length() - 1);
     }


### PR DESCRIPTION
When creating an `ArrayListSpaceSeperated`, it interprets \s as a space. If a literal \s is required, \\s can be used.
In particular this should allow [ ] as a todo keyword.